### PR TITLE
Survive unexpected kwargs

### DIFF
--- a/xivo_lib_rest_client/client.py
+++ b/xivo_lib_rest_client/client.py
@@ -45,6 +45,8 @@ class BaseClient(object):
         self.https = https
         self.timeout = timeout
         self.verify_certificate = verify_certificate
+        if kwargs:
+            logger.info('%s received unexpected arguments: %s', self.__class__.__name__, kwargs)
         self._load_plugins()
 
     def _load_plugins(self):

--- a/xivo_lib_rest_client/client.py
+++ b/xivo_lib_rest_client/client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2014-2015 Avencall
+# Copyright (C) 2014-2016 Avencall
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -36,7 +36,8 @@ class BaseClient(object):
                  token=None,
                  https=True,
                  timeout=10,
-                 verify_certificate=True):
+                 verify_certificate=True,
+                 **kwargs):
         self.host = host
         self.port = port
         self.version = version

--- a/xivo_lib_rest_client/tests/test_client.py
+++ b/xivo_lib_rest_client/tests/test_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2014-2015 Avencall
+# Copyright (C) 2014-2016 Avencall
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -114,7 +114,8 @@ class TestBaseClient(unittest.TestCase):
                    https=None,
                    timeout=None,
                    verify_certificate=None,
-                   token=None):
+                   token=None,
+                   **kwargs):
         return Client(host=host,
                       port=port,
                       version=version,
@@ -123,7 +124,12 @@ class TestBaseClient(unittest.TestCase):
                       https=https,
                       timeout=timeout,
                       verify_certificate=verify_certificate,
-                      token=token)
+                      token=token,
+                      **kwargs)
+
+    def test_that_extra_kwargs_are_ignored(self):
+        self.new_client(patate=True)
+        # No exception
 
     def test_given_no_https_then_http_used(self):
         client = self.new_client(https=False)

--- a/xivo_lib_rest_client/tests/test_client.py
+++ b/xivo_lib_rest_client/tests/test_client.py
@@ -27,11 +27,10 @@ from hamcrest import contains_string
 from hamcrest import equal_to
 from hamcrest import ends_with
 from hamcrest import has_entry
-from mock import Mock
-from mock import patch
+from mock import patch, ANY
 from requests.exceptions import Timeout
 
-from ..client import BaseClient
+from ..client import BaseClient, logger
 
 
 class Client(BaseClient):
@@ -127,9 +126,11 @@ class TestBaseClient(unittest.TestCase):
                       token=token,
                       **kwargs)
 
-    def test_that_extra_kwargs_are_ignored(self):
+    @patch.object(logger, 'info')
+    def test_that_extra_kwargs_are_ignored(self, logger_info):
         self.new_client(patate=True)
-        # No exception
+
+        logger_info.assert_called_once_with(ANY, 'Client', {'patate': True})
 
     def test_given_no_https_then_http_used(self):
         client = self.new_client(https=False)


### PR DESCRIPTION
This branch allows a client to use a **dict to instantiate a client without having to del or pop unexpected keys. Also prevent an administrator from breaking a service if a typo happens in a configuration file.